### PR TITLE
feat: add commands and routes to use the cli as a sdk STY-80 

### DIFF
--- a/packages/as-stylus/cli/commands/build/analyzers/tree-builder.ts
+++ b/packages/as-stylus/cli/commands/build/analyzers/tree-builder.ts
@@ -2,6 +2,8 @@ import fs from "fs";
 import path from "path";
 
 import { IRContract } from "@/cli/types/ir.types.js";
+import { INTERMEDIATE_REPRESENTATION_PATH } from "@/cli/utils/constants.js";
+import { Logger } from "@/cli/services/logger.js";
 
 /**
  * Exports the contract IR to a JSON file for visualization and analysis
@@ -11,7 +13,7 @@ import { IRContract } from "@/cli/types/ir.types.js";
  */
 export function exportContractToJSON(contract: IRContract, outputDir?: string): string {
   // Create the output directory if it doesn't exist
-  const dir = outputDir || path.resolve("generated", "json");
+  const dir = outputDir || path.resolve(INTERMEDIATE_REPRESENTATION_PATH, "json");
   fs.mkdirSync(dir, { recursive: true });
 
   // Create filenames for complete contract and individual methods
@@ -60,7 +62,7 @@ export function exportContractToJSON(contract: IRContract, outputDir?: string): 
   const indexFilePath = path.join(dir, `${contract.name}-index.json`);
   fs.writeFileSync(indexFilePath, JSON.stringify(indexData, null, 2));
 
-  console.log(`Contract IR exported as JSON to: ${contractFilePath}`);
+  Logger.getInstance().info(`Contract IR exported as JSON to: ${contractFilePath}`);
   return contractFilePath;
 }
 
@@ -116,11 +118,11 @@ export function generateContractTree(contract: IRContract): any {
   };
 
   // Save the tree structure for visualization
-  const dir = path.resolve("generated", "json");
+  const dir = path.resolve(INTERMEDIATE_REPRESENTATION_PATH, "json");
   fs.mkdirSync(dir, { recursive: true });
   const treeFilePath = path.join(dir, `${contract.name}-tree.json`);
   fs.writeFileSync(treeFilePath, JSON.stringify(tree, null, 2));
 
-  console.log(`Contract tree structure exported to: ${treeFilePath}`);
+  Logger.getInstance().info(`Contract tree structure exported to: ${treeFilePath}`);
   return tree;
 }

--- a/packages/as-stylus/cli/commands/build/build-runner.ts
+++ b/packages/as-stylus/cli/commands/build/build-runner.ts
@@ -13,10 +13,12 @@ import { transformFromIR } from "./transformers/index.js";
 
 export class BuildRunner extends IRBuilder<void> {
   private projectFinder: ProjectFinder;
+  private buildPath: string;
 
-  constructor(contractsRoot: string, errorManager: ErrorManager) {
+  constructor(contractsRoot: string, buildPath: string, errorManager: ErrorManager) {
     super(errorManager);
     this.projectFinder = new ProjectFinder(contractsRoot, errorManager);
+    this.buildPath = buildPath;
   }
 
   validate(): boolean {
@@ -24,34 +26,32 @@ export class BuildRunner extends IRBuilder<void> {
   }
 
   buildIR(): void {
-    const projects = this.projectFinder.getAllProjects();
+    const project = this.projectFinder.getCurrentProject();
 
-    projects.forEach((project) => {
-      const contractPaths = this.projectFinder.getAllContractPaths(project);
-      const projectName = project.split("/").pop()!;
+    const contractPaths = this.projectFinder.getAllContractPaths(project);
+    const projectName = project.split("/").pop()!;
 
-      contractPaths.forEach((contractPath) => {
-        const projectTargetPath = path.join(path.dirname(project), ".dist", projectName);
-        const contractName = contractPath.split("/").pop()!;
-        const transformedPath = path.join(
-          projectTargetPath,
-          `${contractName.replace(".ts", "")}.transformed.ts`
-        );
+    contractPaths.forEach((contractPath) => {
+      const projectTargetPath = path.join(path.dirname(project), projectName, this.buildPath);
+      const contractName = contractPath.split("/").pop()!;
+      const transformedPath = path.join(
+        projectTargetPath,
+        `${contractName.replace(".ts", "")}.transformed.ts`
+      );
 
-        if (!fs.existsSync(projectTargetPath)) {
-          Logger.getInstance().info(`Creating project: ${projectName}`);
-          fs.mkdirSync(projectTargetPath, { recursive: true });
-        }
+      if (!fs.existsSync(projectTargetPath)) {
+        Logger.getInstance().info(`Creating project: ${projectName}`);
+        fs.mkdirSync(projectTargetPath, { recursive: true });
+      }
 
-        Logger.getInstance().info(`Processing: ${contractPath} -> ${transformedPath}`);
-        fs.copyFileSync(contractPath, transformedPath);
+      Logger.getInstance().info(`Processing: ${contractPath} -> ${transformedPath}`);
+      fs.copyFileSync(contractPath, transformedPath);
 
-        const contract: IRContract = applyAnalysis(transformedPath, this.errorManager);
-        buildProject(transformedPath, contract);
-        transformFromIR(projectTargetPath, contract);
+      const contract: IRContract = applyAnalysis(transformedPath, this.errorManager);
+      buildProject(transformedPath, contract);
+      transformFromIR(projectTargetPath, contract);
 
-        Logger.getInstance().info(`Generated contract project at: ${projectTargetPath}`);
-      });
+      Logger.getInstance().info(`Generated contract project at: ${projectTargetPath}`);
     });
   }
 } 

--- a/packages/as-stylus/cli/commands/build/build.ts
+++ b/packages/as-stylus/cli/commands/build/build.ts
@@ -1,13 +1,17 @@
 import path from "path";
+import { Command } from 'commander';
 
 import { ErrorManager } from "./analyzers/shared/error-manager.js";
 import { BuildRunner } from "./build-runner.js";
+import { BUILD_PATH } from "@/cli/utils/constants.js";
 
 export function runBuild() {
-  const contractsRoot = path.resolve(process.cwd(), "../contracts");
+  const contractsRoot = path.resolve(process.cwd());
   const errorManager = new ErrorManager();
-  const runner = new BuildRunner(contractsRoot, errorManager);
+  const runner = new BuildRunner(contractsRoot, BUILD_PATH, errorManager);
   runner.validateAndBuildIR();
 }
 
-runBuild();
+export const buildCommand = new Command('build')
+  .description('Build a Stylus project')
+  .action(runBuild);

--- a/packages/as-stylus/cli/commands/build/builder/build-abi.ts
+++ b/packages/as-stylus/cli/commands/build/builder/build-abi.ts
@@ -1,8 +1,8 @@
-import fs from "fs";
 import path from "path";
-
+import { writeFile } from "@/cli/utils/fs.js";
 import { AbiItem, AbiInput, AbiOutput } from "@/cli/types/abi.types.js";
 import { IRContract } from "@/cli/types/ir.types.js";
+import { ABI_PATH } from "@/cli/utils/constants.js";
 
 export function buildAbi(targetPath: string, contract: IRContract) {
   const abi: AbiItem[] = [];
@@ -44,7 +44,8 @@ export function buildAbi(targetPath: string, contract: IRContract) {
     });
   }
 
-  fs.writeFileSync(path.join(targetPath, "abi.json"), JSON.stringify(abi, null, 2));
+  const abiPath = path.join(targetPath, ABI_PATH, `${contract.name}-abi.json`);
+  writeFile(abiPath, JSON.stringify(abi, null, 2));
 }
 
 function convertType(type: string): string {

--- a/packages/as-stylus/cli/commands/build/builder/build-entrypoint.ts
+++ b/packages/as-stylus/cli/commands/build/builder/build-entrypoint.ts
@@ -1,8 +1,8 @@
-import fs from "fs";
 import path from "path";
 import { generateArgsLoadBlock } from "../transformers/utils/args.js";
 import { IRContract } from "@/cli/types/ir.types.js";
 import { getUserEntrypointTemplate } from "@/templates/entry-point.js";
+import { writeFile } from "@/cli/utils/fs.js";
 
 export function generateUserEntrypoint(contract: IRContract) {
   const imports: string[] = [];
@@ -58,5 +58,5 @@ export function buildEntrypoint(userFilePath: string, contract: IRContract): voi
   indexTemplate = indexTemplate.replace("// @logic_imports", imports);
   indexTemplate = indexTemplate.replace("// @user_entrypoint", entrypointBody);
 
-  fs.writeFileSync(path.join(contractBasePath, "entrypoint.ts"), indexTemplate);
+  writeFile(path.join(contractBasePath, "entrypoint.ts"), indexTemplate);
 }

--- a/packages/as-stylus/cli/commands/generate/generate-runner.ts
+++ b/packages/as-stylus/cli/commands/generate/generate-runner.ts
@@ -1,0 +1,48 @@
+import fs from "fs";
+import { IRBuilder } from "../build/analyzers/shared/ir-builder.js";
+import { ErrorManager } from "../build/analyzers/shared/error-manager.js";
+import { ProjectGenerator } from "./generator/project-generator.js";
+import { Logger } from "@/cli/services/logger.js";
+
+export class GenerateRunner {
+  private errorManager: ErrorManager;
+  private contractsRoot: string;
+  private projectName: string;
+
+  constructor(contractsRoot: string, errorManager: ErrorManager, projectName: string) {
+    this.contractsRoot = contractsRoot;
+    this.projectName = projectName;
+    this.errorManager = errorManager;
+  }
+
+  validate(): boolean {
+    if (!this.projectName) {
+      this.errorManager.addSemanticError("Project name is required", this.contractsRoot);
+      return false;
+    }
+
+    const targetPath = `${this.contractsRoot}/${this.projectName}`;
+    if (fs.existsSync(targetPath)) {
+      this.errorManager.addSemanticError(
+        `Project "${this.projectName}" already exists`,
+        targetPath,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  validateAndGenerate(): void {
+    if (!this.validate()) {
+      process.exit(1);
+    }
+
+    const generator = new ProjectGenerator(this.contractsRoot, this.projectName);
+    generator.generate();
+
+    Logger.getInstance().info(
+      `Project "${this.projectName}" created successfully at ${this.contractsRoot}/${this.projectName}`,
+    );
+  }
+}

--- a/packages/as-stylus/cli/commands/generate/generate.ts
+++ b/packages/as-stylus/cli/commands/generate/generate.ts
@@ -1,144 +1,17 @@
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import { Command } from "commander";
+import { ErrorManager } from "../build/analyzers/shared/error-manager.js";
+import { GenerateRunner } from "./generate-runner.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const baseContractsPath = path.resolve(__dirname, "../../../../../contracts");
-
-const contractName = process.argv[2];
-
-if (!contractName) {
-  console.error("Missing contract name. Usage: npm run generate <contract-name>");
-  process.exit(1);
+export function runGenerate(projectName: string) {
+  const contractsRoot = process.cwd();
+  const errorManager = new ErrorManager();
+  const runner = new GenerateRunner(contractsRoot, errorManager, projectName);
+  runner.validateAndGenerate();
 }
 
-if (!fs.existsSync(baseContractsPath)) {
-  fs.mkdirSync(baseContractsPath);
-}
-
-const targetPath = path.join(baseContractsPath, contractName);
-
-if (fs.existsSync(targetPath)) {
-  console.error(`Contract "${contractName}" already exists`);
-  process.exit(1);
-}
-
-fs.mkdirSync(targetPath);
-
-// asconfig.json
-fs.writeFileSync(
-  path.join(targetPath, "asconfig.json"),
-  JSON.stringify(
-    {
-      targets: {
-        debug: {
-          outFile: "build/module.wasm",
-          textFile: "build/module.wat",
-          jsFile: "build/module.js",
-          optimizeLevel: 0,
-          shrinkLevel: 0,
-          sourceMap: true,
-          noAssert: true,
-          debug: true,
-        },
-        release: {
-          outFile: "build/module.wasm",
-          textFile: "build/module.wat",
-          jsFile: "build/module.js",
-          sourceMap: true,
-          optimizeLevel: 0,
-          shrinkLevel: 0,
-          noAssert: true,
-          converge: true,
-        },
-      },
-      options: {
-        bindings: "esm",
-        runtime: "stub",
-      },
-    },
-    null,
-    2,
-  ),
-);
-
-// index.ts
-fs.writeFileSync(
-  path.join(targetPath, "contract.ts"),
-  `// @ts-nocheck
-@Contract
-export class Counter {
-  static counter: U256;
-
-  constructor() {
-    Counter.counter = U256Factory.create();
-  }
-
-  @External
-  static increment(): void {
-    const delta: U256 = U256Factory.fromString("1");
-    Counter.counter = Counter.counter.add(delta);
-  }
-
-  @External
-  static decrement(): void {
-    const delta: U256 = U256Factory.fromString("1");
-    Counter.counter = Counter.counter.sub(delta);
-  }
-
-  @View
-  static get(): u64 {
-    return Counter.counter.toString();
-  }
-}
-`,
-);
-
-// package.json
-fs.writeFileSync(
-  path.join(targetPath, "package.json"),
-  JSON.stringify(
-    {
-      name: contractName,
-      version: "1.0.0",
-      description: "",
-      main: "index.js",
-      scripts: {
-        compile: "cd .dist && npm run compile",
-        check: "cd .dist && npm run check",
-        deploy: "cd .dist && npm run deploy",
-      },
-      author: "",
-      license: "ISC",
-      type: "module",
-      exports: {
-        ".": {
-          import: "./build/release.js",
-          types: "./build/release.d.ts",
-        },
-      },
-      devDependencies: {
-        assemblyscript: "^0.27.35",
-      },
-    },
-    null,
-    2,
-  ),
-);
-
-// tsconfig.json
-fs.writeFileSync(
-  path.join(targetPath, "tsconfig.json"),
-  JSON.stringify(
-    {
-      extends: "assemblyscript/std/assembly.json",
-      include: ["contract.ts"],
-    },
-    null,
-    2,
-  ),
-);
-
-console.log(`Contract "${contractName}" created successfully at ${targetPath}`);
+export const generateCommand = new Command("generate")
+  .description("Generate a new Stylus project")
+  .argument("<project-name>", "Name of the project to generate")
+  .action((projectName: string) => {
+    runGenerate(projectName);
+  });

--- a/packages/as-stylus/cli/commands/generate/generator/build-asconfig.ts
+++ b/packages/as-stylus/cli/commands/generate/generator/build-asconfig.ts
@@ -1,0 +1,41 @@
+import { BUILD_WASM_PATH } from "@/cli/utils/constants.js";
+import fs from "fs";
+import path from "path";
+
+export function buildAsconfig(targetPath: string) {
+  fs.writeFileSync(
+    path.join(targetPath, "asconfig.json"),
+    JSON.stringify(
+      {
+        targets: {
+          debug: {
+            outFile: `${BUILD_WASM_PATH}/module.wasm`,
+            textFile: `${BUILD_WASM_PATH}/module.wat`,
+            jsFile: `${BUILD_WASM_PATH}/module.js`,
+            optimizeLevel: 0,
+            shrinkLevel: 0,
+            sourceMap: true,
+            noAssert: true,
+            debug: true,
+          },
+          release: {
+            outFile: `${BUILD_WASM_PATH}/module.wasm`,
+            textFile: `${BUILD_WASM_PATH}/module.wat`,
+            jsFile: `${BUILD_WASM_PATH}/module.js`,
+            sourceMap: true,
+            optimizeLevel: 0,
+            shrinkLevel: 0,
+            noAssert: true,
+            converge: true,
+          },
+        },
+        options: {
+          bindings: "esm",
+          runtime: "stub",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/packages/as-stylus/cli/commands/generate/generator/build-contract.ts
+++ b/packages/as-stylus/cli/commands/generate/generator/build-contract.ts
@@ -1,0 +1,7 @@
+import fs from "fs";
+import path from "path";
+import { getCounterTemplate } from "@/templates/counter.js";
+
+export function buildContract(targetPath: string) {
+  fs.writeFileSync(path.join(targetPath, "contract.ts"), getCounterTemplate());
+}

--- a/packages/as-stylus/cli/commands/generate/generator/build-package-json.ts
+++ b/packages/as-stylus/cli/commands/generate/generator/build-package-json.ts
@@ -1,0 +1,36 @@
+import { BUILD_PATH, BUILD_WASM_PATH } from "@/cli/utils/constants.js";
+import fs from "fs";
+import path from "path";
+
+export function buildPackageJson(targetPath: string, projectName: string) {
+  fs.writeFileSync(
+    path.join(targetPath, "package.json"),
+    JSON.stringify(
+      {
+        name: projectName,
+        version: "1.0.0",
+        description: "",
+        main: "index.js",
+        scripts: {
+          compile: `cd ${BUILD_PATH} && npm run compile`,
+          check: `cd ${BUILD_PATH} && npm run check`,
+          deploy: `cd ${BUILD_PATH} && npm run deploy`,
+        },
+        author: "",
+        license: "ISC",
+        type: "module",
+        exports: {
+          ".": {
+            import: `${BUILD_WASM_PATH}/release.js`,
+            types: `${BUILD_WASM_PATH}/release.d.ts`,
+          },
+        },
+        devDependencies: {
+          assemblyscript: "^0.27.35",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/packages/as-stylus/cli/commands/generate/generator/build-tsconfig.ts
+++ b/packages/as-stylus/cli/commands/generate/generator/build-tsconfig.ts
@@ -1,0 +1,16 @@
+import fs from "fs";
+import path from "path";
+
+export function buildTsconfig(targetPath: string) {
+  fs.writeFileSync(
+    path.join(targetPath, "tsconfig.json"),
+    JSON.stringify(
+      {
+        extends: "assemblyscript/std/assembly.json",
+        include: ["contract.ts"],
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/packages/as-stylus/cli/commands/generate/generator/project-generator.ts
+++ b/packages/as-stylus/cli/commands/generate/generator/project-generator.ts
@@ -1,0 +1,25 @@
+import path from "path";
+import { ensureDir } from "@/cli/utils/fs.js";
+import { buildAsconfig } from "./build-asconfig.js";
+import { buildTsconfig } from "./build-tsconfig.js";
+import { buildPackageJson } from "./build-package-json.js";
+import { buildContract } from "./build-contract.js";
+
+export class ProjectGenerator {
+  private contractsRoot: string;
+  private projectName: string;
+
+  constructor(contractsRoot: string, projectName: string) {
+    this.contractsRoot = contractsRoot;
+    this.projectName = projectName;
+  }
+
+  generate(): void {
+    const targetPath = ensureDir(path.join(this.contractsRoot, this.projectName));
+
+    buildAsconfig(targetPath);
+    buildTsconfig(targetPath);
+    buildPackageJson(targetPath, this.projectName);
+    buildContract(targetPath);
+  }
+}

--- a/packages/as-stylus/cli/commands/lint/lint.ts
+++ b/packages/as-stylus/cli/commands/lint/lint.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { ErrorManager } from "../build/analyzers/shared/error-manager.js";
 import { LintRunner } from "./lint-runner.js";
+import { Command } from "commander";
 
 export function runLint() {
   const contractsRoot = path.resolve(process.cwd(), "../contracts");
@@ -9,4 +10,6 @@ export function runLint() {
   runner.lint();
 }
 
-runLint();
+export const lintCommand = new Command("lint")
+  .description("Lint a Stylus contract")
+  .action(runLint);

--- a/packages/as-stylus/cli/index.ts
+++ b/packages/as-stylus/cli/index.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import { generateCommand } from "./commands/generate/generate.js";
+import { buildCommand } from "./commands/build/build.js";
+import { lintCommand } from "./commands/lint/lint.js";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { readFileSync } from "fs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJson = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf-8"));
+
+const program = new Command();
+
+program
+  .name("as-stylus")
+  .description("SDK to build AssemblyScript contracts for Stylus")
+  .version(packageJson.version);
+
+program.addCommand(generateCommand);
+program.addCommand(buildCommand);
+program.addCommand(lintCommand);
+
+program.parse();

--- a/packages/as-stylus/cli/services/project-finder.ts
+++ b/packages/as-stylus/cli/services/project-finder.ts
@@ -8,6 +8,10 @@ export class ProjectFinder {
     private readonly errorManager: ErrorManager,
   ) {}
 
+  getCurrentProject(): string {
+    return path.resolve(process.cwd());
+  }
+
   getAllProjects(): string[] {
     const folders = fs.readdirSync(this.contractsRoot);
     if (folders.length === 0) {

--- a/packages/as-stylus/cli/utils/constants.ts
+++ b/packages/as-stylus/cli/utils/constants.ts
@@ -1,0 +1,4 @@
+export const BUILD_PATH = "artifacts";
+export const BUILD_WASM_PATH = "build";
+export const INTERMEDIATE_REPRESENTATION_PATH = `${BUILD_PATH}/intermediate-representation`;
+export const ABI_PATH = "abi";

--- a/packages/as-stylus/cli/utils/fs.ts
+++ b/packages/as-stylus/cli/utils/fs.ts
@@ -1,0 +1,42 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Ensures a directory exists, creating it if necessary
+ * @param dirPath Path to the directory to ensure exists
+ * @returns The absolute path to the directory
+ */
+export function ensureDir(dirPath: string): string {
+  const absolutePath = path.resolve(dirPath);
+  if (!fs.existsSync(absolutePath)) {
+    fs.mkdirSync(absolutePath, { recursive: true });
+  }
+  return absolutePath;
+}
+
+/**
+ * Writes content to a file, ensuring the directory exists
+ * @param filePath Path to the file to write
+ * @param content Content to write to the file
+ * @param options Optional write options
+ */
+export function writeFile(
+  filePath: string,
+  content: string | Buffer,
+  options?: fs.WriteFileOptions,
+): void {
+  const dirPath = path.dirname(filePath);
+  ensureDir(dirPath);
+  fs.writeFileSync(filePath, content, options);
+}
+
+/**
+ * Copies a file to a destination, ensuring the destination directory exists
+ * @param srcPath Source file path
+ * @param destPath Destination file path
+ */
+export function copyFile(srcPath: string, destPath: string): void {
+  const dirPath = path.dirname(destPath);
+  ensureDir(dirPath);
+  fs.copyFileSync(srcPath, destPath);
+}

--- a/packages/as-stylus/package.json
+++ b/packages/as-stylus/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "bin": {
+    "as-stylus": "dist/cli/index.js",
     "test-sdk": "dist/cli/build.js"
   },
   "engines": {
@@ -40,6 +41,7 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
+    "commander": "^12.0.0",
     "keccak256": "^1.0.6",
     "ts-morph": "^25.0.1",
     "tsc-alias": "^1.8.16"

--- a/packages/as-stylus/templates/counter.ts
+++ b/packages/as-stylus/templates/counter.ts
@@ -1,0 +1,31 @@
+export function getCounterTemplate(): string {
+  return `
+// @ts-nocheck
+
+@Contract
+export class Counter {
+  static counter: U256;
+
+  constructor() {
+    Counter.counter = U256Factory.create();
+  }
+
+  @External
+  static increment(): void {
+    const delta: U256 = U256Factory.fromString("1");
+    Counter.counter = Counter.counter.add(delta);
+  }
+
+  @External
+  static decrement(): void {
+    const delta: U256 = U256Factory.fromString("1");
+    Counter.counter = Counter.counter.sub(delta);
+  }
+
+  @View
+  static get(): u64 {
+    return Counter.counter.toString();
+  }
+}
+`;
+}

--- a/packages/as-stylus/templates/entry-point.ts
+++ b/packages/as-stylus/templates/entry-point.ts
@@ -5,9 +5,9 @@ export function getUserEntrypointTemplate(): string {
 
 // Auto-generated contract template
 
-import { __keep_imports } from "../../../as-stylus/core/modules/keep-imports";
-import { read_args, write_result } from "../../../as-stylus/core/modules/hostio";
-import { initHeap } from "../../../as-stylus/core/modules/memory";
+import { __keep_imports } from "as-stylus/core/modules/keep-imports";
+import { read_args, write_result } from "as-stylus/core/modules/hostio";
+import { initHeap } from "as-stylus/core/modules/memory";
 
 // @logic_imports
 

--- a/packages/as-stylus/templates/entrypoint.ts
+++ b/packages/as-stylus/templates/entrypoint.ts
@@ -1,0 +1,11 @@
+export function getUserEntrypointTemplate(): string {
+  return `import { write_result } from "../as-stylus/core/modules/hostio";
+
+// @logic_imports
+
+export function main(selector: u32): i32 {
+// @user_entrypoint
+  return -1;
+}
+`;
+}


### PR DESCRIPTION
## Ticket  
[JIRA: STY-80 – Add CLI Logic and Move Path Constants](https://wakeuplabs.atlassian.net/browse/STY-80)

---

## Description  

This PR introduces the necessary CLI logic to support command-line interaction with the tool. It also refactors the project structure by moving hardcoded directory paths into a centralized `constants` module, improving code maintainability and clarity.

---

## Considerations  

- This PR is **nested** and depends on the successful merge of `fix/ir-building`.  
- Before merging:
  1. Ensure `fix/ir-building` is merged into `develop`.
  2. Rebase this branch onto the updated `develop` branch.

---

## Screenshot  

<img width="543" alt="CLI Output Preview" src="https://github.com/user-attachments/assets/65afe337-7013-4e72-8362-2ae8a6cd5b69" />
